### PR TITLE
feat: add the builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # Unreleased
 
 
+# v2.3.0 - 2026-01-22
+
+- Added `Builder` class for incrementally constructing multi-line strings
+
+
 # v2.2.0 - 2025-05-19
 
 - Added `strip_trailing_whitespace()` method.

--- a/README.md
+++ b/README.md
@@ -372,3 +372,246 @@ The code-block above will produce output like this:
 * so very nice             *
 ****************************
 ```
+
+
+## Builder class
+
+The `Builder` class provides a convenient way to incrementally construct multi-line strings. It's especially useful when
+you need to build complex text output programmatically, where different parts of the text may be generated conditionally
+or in loops.
+
+For the most common usecases, parts added to the builder will be dedenteds automatically (though this behavior is
+configurable). Then, the parts are joined together with newlines (though this is also configurable) when the Builder is
+rendered to string. This makes it easy to work with indented triple-quoted strings in your code while producing clean
+output.
+
+
+### Basic Usage
+
+```python
+from snick import Builder
+
+builder = Builder()
+builder.add("First line")
+builder.add("Second line")
+print(builder)
+```
+
+This will output:
+```
+First line
+Second line
+```
+
+
+### Adding Multiple Parts at Once
+
+You can add multiple parts in a single call:
+
+```python
+builder = Builder()
+builder.add(
+    "Line 1",
+    "Line 2",
+    "Line 3",
+)
+print(builder)
+```
+
+
+### Automatic Dedenting
+
+By default, the Builder will dedent each part, making it easy to use indented triple-quoted strings:
+
+```python
+builder = Builder()
+builder.add(
+    """
+    This text is indented in the code
+    but will be dedented in the output
+    """
+)
+builder.add(
+    """
+    Same with this text
+    it looks nice in the code
+    """
+)
+print(builder)
+```
+
+This produces:
+```
+This text is indented in the code
+but will be dedented in the output
+Same with this text
+it looks nice in the code
+```
+
+To preserve indentation, set `should_dedent=False`:
+
+```python
+builder = Builder()
+builder.add("    Keep this indented", should_dedent=False)
+```
+
+
+### Adding Blank Lines
+
+There are several ways to add blank lines with the Builder:
+
+#### Using `blanks_between`
+
+The `blanks_between` parameter inserts blanks between multiple parts in a single `add()` call:
+
+```python
+builder = Builder()
+builder.add(
+    "Section 1",
+    "Section 2",
+    "Section 3",
+    blanks_between=1,
+)
+print(builder)
+```
+
+This outputs:
+```
+Section 1
+
+Section 2
+
+Section 3
+```
+
+Note that `blanks_between` only applies within a single `add()` call. Multiple `add()` calls will not insert blanks
+between them by default:
+
+```python
+builder = Builder()
+builder.add("First call")
+builder.add("Second call")
+print(builder)
+```
+
+This produces:
+```
+First call
+Second call
+```
+
+#### Using `blanks_before` and `blanks_after`
+
+To add blanks before or after a group of parts, use the `blanks_before` and `blanks_after` parameters:
+
+```python
+builder = Builder()
+builder.add("first")
+builder.add("second", blanks_before=1, blanks_after=1)
+builder.add("third")
+print(builder)
+```
+
+This outputs:
+```
+first
+
+second
+
+third
+```
+
+These parameters work with both `add()` and `extend()` methods.
+
+#### Using `add_blank()` and `add_blanks()`
+
+For more explicit control, you can use the `add_blank()` and `add_blanks()` methods:
+
+```python
+builder = Builder()
+builder.add("first")
+builder.add_blanks(2)
+builder.add("second")
+print(builder)
+```
+
+This outputs:
+```
+first
+
+
+second
+```
+
+
+### Customizing the Join String
+
+By default, parts are joined with newlines, but you can customize this:
+
+```python
+builder = Builder(join_str=" | ")
+builder.add("one", "two", "three")
+print(builder)
+```
+
+This outputs:
+```
+one | two | three
+```
+
+
+### Customizing Blank Lines
+
+You can also customize what a "blank" line looks like:
+
+```python
+builder = Builder(blank="---")
+builder.add("First", "Second", blanks_between=2)
+print(builder)
+```
+
+This produces:
+```
+First
+---
+---
+Second
+```
+
+
+### Practical Example
+
+Here's a realistic example of building a formatted report:
+
+```python
+from snick import Builder
+
+def generate_report(title, items, footer):
+    builder = Builder()
+
+    builder.add(f"=== {title} ===", blanks_after=1)
+
+    if items:
+        builder.add("Items:")
+        builder.extend((f"  {i}. {item}" for (i, item) in enumerate(items, 1)), should_dedent=False)
+    else:
+        builder.add("_No items found._")
+
+    builder.add(f"--- {footer} ---", blanks_before=1)
+    return builder
+
+
+print(generate_report("Daily Report", ["Task A", "Task B", "Task C"], "End of Report"))
+```
+
+This would output:
+```
+=== Daily Report ===
+
+Items:
+  1. Task A
+  2. Task B
+  3. Task C
+
+--- End of Report ---
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snick"
-version = "2.2.0"
+version = "2.3.0"
 description = "Text gadgets that help with indentation"
 authors = [
     {name = "Tucker Beck", email ="tucker.beck@gmail.com"},

--- a/src/snick/__init__.py
+++ b/src/snick/__init__.py
@@ -1,3 +1,4 @@
+from snick.builder import Builder
 from snick.methods import (
     conjoin,
     dedent,
@@ -14,6 +15,7 @@ from snick.methods import (
 )
 
 __all__ = [
+    "Builder",
     "dedent",
     "conjoin",
     "dedent_all",

--- a/src/snick/builder.py
+++ b/src/snick/builder.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass, field
+from typing import override
+
+from snick.methods import dedent
+
+@dataclass
+class Builder:
+    """
+    Builds a string from parts that are incrementally added.
+
+    This is most useful when building multi-line strings where you want to add parts as you go and then
+    produce a final, joined string.
+    """
+    parts: list[str] = field(default_factory=list)
+    join_str: str = "\n"
+    blank: str = ""
+
+    @override
+    def __str__(self) -> str:
+        return self.join_str.join(self.parts)
+
+    def add(self, *parts: str, should_dedent: bool = True, blanks_between: int = 0, blanks_before: int = 0, blanks_after: int = 0) -> None:
+        """
+        Add a new part(s) to the builder.
+
+        Args:
+            parts:          One or more string parts to add.
+            should_dedent:  If `True`, dedent each part before adding it. Defaults to `True`.
+            blanks_between: Number of blanks to insert between each part for multiple parts. Defaults to `0`.
+            blanks_before:  Number of blanks to insert before the first part. Defaults to `0`.
+            blanks_after:   Number of blanks to insert after the last part. Defaults to `0`.
+        """
+        self.add_blanks(blanks_before)
+        for i, part in enumerate(parts):
+            if i > 0:
+                self.parts.extend([self.blank] * blanks_between)
+            if should_dedent:
+                part = dedent(part)
+            self.parts.append(part)
+        self.add_blanks(blanks_after)
+
+    def extend(self, parts: list[str], should_dedent: bool = True, blanks_between: int = 0, blanks_before: int = 0, blanks_after: int = 0) -> None:
+        """
+        Add new parts to the builder.
+
+        This is just a convenience method that takes a list of parts instead of variadic arguments.
+
+        Args:
+            parts:          One or more string parts to add.
+            should_dedent:  If `True`, dedent each part before adding it. Defaults to `True`.
+            blanks_between: Number of blanks to insert between each part for multiple parts. Defaults to `0`.
+            blanks_before:  Number of blanks to insert before the first part. Defaults to `0`.
+            blanks_after:   Number of blanks to insert after the last part. Defaults to `0`.
+        """
+        self.add(*parts, should_dedent=should_dedent, blanks_between=blanks_between, blanks_before=blanks_before, blanks_after=blanks_after)
+
+    def add_blanks(self, count: int) -> None:
+        """
+        Add blanks to the builder.
+
+        Args:
+            count: Number of blank lines to add.
+        """
+        self.parts.extend([self.blank] * count)
+
+    def add_blank(self) -> None:
+        """
+        Add a single blank to the builder.
+        """
+        self.add_blanks(1)

--- a/src/snick/methods.py
+++ b/src/snick/methods.py
@@ -3,7 +3,7 @@ import sys
 import textwrap
 from typing import TextIO, Any, cast
 
-import pprintpp  # pyright: ignore[reportMissingTypeStubs]
+import pprintpp  # basedpyright: ignore[reportMissingTypeStubs]
 
 
 def indent(text: str, prefix: str = "    ", skip_first_line: bool = False, **kwargs: Any) -> str:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,292 @@
+from snick.builder import Builder
+from snick.methods import dedent
+
+
+def test_builder_basic():
+    builder = Builder()
+    builder.add("First line", "Second line")
+    builder.add(
+        """
+        Dedented third line
+        Dedented fourth line
+        """
+    )
+    builder.add(
+        "    Indented fifth line",
+        "    Indented sixth line",
+        should_dedent=False,
+    )
+    builder.add(
+        "Seventh line",
+        "Eighth line",
+        "Ninth line",
+        blanks_between=2,
+    )
+
+    assert str(builder) == dedent(
+        """
+        First line
+        Second line
+        Dedented third line
+        Dedented fourth line
+            Indented fifth line
+            Indented sixth line
+        Seventh line
+
+
+        Eighth line
+
+
+        Ninth line
+        """
+    )
+
+
+def test_builder_empty():
+    builder = Builder()
+    assert str(builder) == ""
+
+
+def test_builder_single_part():
+    builder = Builder()
+    builder.add("Single line")
+    assert str(builder) == "Single line"
+
+
+def test_builder_custom_join_str():
+    builder = Builder(join_str=" | ")
+    builder.add("first", "second", "third")
+    assert str(builder) == "first | second | third"
+
+
+def test_builder_custom_blank():
+    builder = Builder(blank="---")
+    builder.add("first", "second", blanks_between=2)
+    assert str(builder) == dedent(
+        """
+        first
+        ---
+        ---
+        second
+        """
+    )
+
+
+def test_builder_no_dedent():
+    builder = Builder()
+    builder.add("    indented", should_dedent=False)
+    assert str(builder) == "    indented"
+
+
+def test_builder_blanks_between_multiple_adds():
+    builder = Builder()
+    builder.add("first")
+    builder.add("second")
+    assert str(builder) == dedent(
+        """
+        first
+        second
+        """
+    )
+
+
+def test_builder_blanks_between():
+    builder = Builder()
+    builder.add("first", "second", "third", blanks_between=2)
+    assert str(builder) == dedent(
+        """
+        first
+
+
+        second
+
+
+        third
+        """
+    )
+
+
+def test_builder_mixed_dedent():
+    builder = Builder()
+    builder.add("    dedented", should_dedent=True)
+    builder.add("    not dedented", should_dedent=False)
+    assert str(builder) == "dedented\n    not dedented"
+
+
+def test_builder_multiple_calls_with_blanks():
+    builder = Builder()
+    builder.add("first", "second", blanks_between=1)
+    builder.add("third")
+    assert str(builder) == dedent(
+        """
+        first
+
+        second
+        third
+        """
+    )
+
+
+def test_builder_empty_string_part():
+    builder = Builder()
+    builder.add("first", "", "third")
+    assert str(builder) == dedent(
+        """
+        first
+
+        third
+        """
+    )
+
+
+def test_builder_multiline_dedent():
+    builder = Builder()
+    builder.add(
+        """
+        line one
+        line two
+        """
+    )
+    assert str(builder) == dedent(
+        """
+        line one
+        line two
+        """
+    )
+
+
+def test_builder_extend():
+    builder = Builder()
+    builder.extend(["First line", "Second line"])
+    builder.extend([
+        """
+        Dedented third line
+        Dedented fourth line
+        """
+    ])
+    builder.extend(
+        [
+            "    Indented fifth line",
+            "    Indented sixth line",
+        ],
+        should_dedent=False,
+    )
+    builder.extend(
+        [
+            "Seventh line",
+            "Eighth line",
+            "Ninth line",
+        ],
+        blanks_between=2,
+    )
+
+    assert str(builder) == dedent(
+        """
+        First line
+        Second line
+        Dedented third line
+        Dedented fourth line
+            Indented fifth line
+            Indented sixth line
+        Seventh line
+
+
+        Eighth line
+
+
+        Ninth line
+        """
+    )
+
+
+def test_builder_add_blank():
+    builder = Builder()
+    builder.add("first")
+    builder.add_blank()
+    builder.add("second")
+    assert str(builder) == dedent(
+        """
+        first
+
+        second
+        """
+    )
+
+
+def test_builder_add_blanks():
+    builder = Builder()
+    builder.add("first")
+    builder.add_blanks(3)
+    builder.add("second")
+    assert str(builder) == dedent(
+        """
+        first
+
+
+
+        second
+        """
+    )
+
+
+def test_builder_add_blanks_before():
+    builder = Builder()
+    builder.add("first")
+    builder.add("second", blanks_before=2)
+    builder.add("third")
+    assert str(builder) == dedent(
+        """
+        first
+
+
+        second
+        third
+        """
+    )
+
+
+def test_builder_add_blanks_after():
+    builder = Builder()
+    builder.add("first", blanks_after=2)
+    builder.add("second")
+    assert str(builder) == dedent(
+        """
+        first
+
+
+        second
+        """
+    )
+
+
+def test_builder_add_blanks_before_and_after():
+    builder = Builder()
+    builder.add("first")
+    builder.add("second", blanks_before=1, blanks_after=1)
+    builder.add("third")
+    assert str(builder) == dedent(
+        """
+        first
+
+        second
+
+        third
+        """
+    )
+
+
+def test_builder_extend_blanks_before_and_after():
+    builder = Builder()
+    builder.add("first")
+    builder.extend(["second", "third"], blanks_before=1, blanks_after=1)
+    builder.add("fourth")
+    assert str(builder) == dedent(
+        """
+        first
+
+        second
+        third
+
+        fourth
+        """
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "snick"
-version = "2.1.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pprintpp" },


### PR DESCRIPTION
Add Builder class for constructing multi-line strings incrementally. Useful for building formatted text, templates, or any multi-line output where parts are added progressively with control over spacing.

- Add Builder dataclass with configurable join string and blank lines
- Support dedenting parts automatically via should_dedent parameter
- Allow flexible blank line insertion (before, after, between parts)
- Provide both add() for variadic args and extend() for lists
- Add comprehensive test coverage
- Update README with usage examples